### PR TITLE
Adds script to discover identifiers missing from Appsflyer's public sheet

### DIFF
--- a/scripts/Appsflyer/requirements.txt
+++ b/scripts/Appsflyer/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4=4.9.1
+requests==2.7.0

--- a/scripts/Appsflyer/scrape_appsflyer.py
+++ b/scripts/Appsflyer/scrape_appsflyer.py
@@ -1,0 +1,56 @@
+import requests
+import re
+
+from bs4 import BeautifulSoup
+
+def scrape_appsflyer():
+    request = requests.get("https://docs.google.com/spreadsheets/d/e/2PACX-1vSqwIBW3FzbrXKqluDQ2hEec7zcvVrxQ02ivWsHnGQTvLMeFmHHjGz1R5TVy6_cqAIVh0pAy4Yud7Qx/pubhtml#")
+    soup = BeautifulSoup(request.content, "html5lib")
+    # print(soup.prettify())
+
+    discovered_networks = []
+
+    sheets_viewport = soup.find("div", attrs = { "id": "sheets-viewport" })
+    sheets_table = sheets_viewport.find("tbody")
+
+    for sheets_row in sheets_table.findAll("tr")[1:]:
+        sheets_row_group = sheets_row.findAll("td")
+
+        if len(sheets_row_group) != 2:
+            continue
+
+        network = {}
+        network["name"] = sheets_row_group[0].text
+        network["network"] = sheets_row_group[1].text
+
+        if not network["name"] or not network["network"]:
+            continue
+
+        discovered_networks.append(network)
+
+    return discovered_networks
+
+def filter_not_found_in_readme(networks):
+    filtered_networks = []
+
+    with open("README.md") as readme_file:
+        readme = readme_file.read()
+
+        for network in networks:
+            if re.search(r"\\|%s" % network["network"].split(".")[0], readme, re.MULTILINE) == None:
+                filtered_networks.append(network)
+        
+    return filtered_networks
+
+
+appsflyer_networks = scrape_appsflyer()
+networks_missing_from_readme = filter_not_found_in_readme(appsflyer_networks)
+
+# for network in appsflyer_networks:
+    # print("Discovered Network: %s [%s]" % (network["name"], network["network"]))
+
+print("Found %i networks, %i require addition." % (len(appsflyer_networks), len(networks_missing_from_readme)))
+print("Networks requiring readme addition:")
+
+for network in networks_missing_from_readme:
+    print("|[%s]()|%s||" % (network["name"].split("_")[0], network["network"].split(".")[0]))


### PR DESCRIPTION
I figure this PR depends on the result of the conversation related to [this issue](https://github.com/skadnetwork/ad-network-ids/issues/17), but this adds `scripts/Appsflyer/scrape_appsflyer.py` to generate readme entries from the public Appsflyer SKAdNetworkIdentifiers sheet (minus URLs and descriptions).

Generated output on 9/14/2020:

```
Found 25 networks, 23 require addition.
Networks requiring readme addition:
|[aarki]()|4fzdc2evr5||
|[adcolony]()|4pfyvq9l8r||
|[adperio]()|vcra2ehyfk||
|[applovin]()|ludvb6z3bs||
|[crossinstall]()|prcb7njmu6||
|[curatemobileltd]()|52fl2v3hgk||
|[feedmob]()|fz2k2k5tej||
|[ironsource]()|su67r6k2v3||
|[lemmonetmobile]()|au67k4efj4||
|[lifestreet]()|t38b2kh725||
|[liftoff]()|7ug5zh24hu||
|[mintegral]()|kbd757ywx3||
|[mobrain]()|5ghnmfs3dh||
|[moloco]()|vcra2ehyfk||
|[pubnative]()|tl55sbb4fm||
|[remerge]()|2u9pt9hc89||
|[smartnewsads]()|9wsyqb3ku7||
|[spotad]()|f73kdq92p3||
|[startapp]()|5l3tpt7t6e||
|[tapjoy]()|ecpz2srf59||
|[thetradedesk]()|uw77j35x4d||
|[unicorn]()|578prtvx9j||
|[unityads]()|4dzt52r2t5||
```

