### PR TITLE
Update ad-network-ids.plist

### DIFF
--- a/ad-network-ids.plist
+++ b/ad-network-ids.plist
@@ -139,6 +139,11 @@
         <key>SKAdNetworkIdentifier</key>
         <string>3rd42ekr43.skadnetwork</string>
     </dict>
+    <dict>
+        <!-- AdzMedia -->
+        <key>SKAdNetworkIdentifier</key>
+        <string>nzq8sh4pbs.skadnetwork</string>
+    </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Adding a new DSP AdzMedia

SSP side integration is located here.
https://developers.mopub.com/skadnetworkids.xml